### PR TITLE
Add copyright notice to license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright 2021 Triad National Security, LLC.
+
 This program is open source under the BSD-3 License.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted


### PR DESCRIPTION
The license states that redistribution must retain the above copyright notice. There is no copyright notice "above". This adds said notice based on the information in README.md

/cc @shawnmjones 